### PR TITLE
Resubmit

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,2 @@
+.eslintrc
+.gitignore

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ A simple http framework to take mundane out of the mundane. Quickly create a bas
 </ul>
 
 <h2>Installation</h2>
+NOTE: This app requires your computer to have Node js v4.x.x installed. 
 ---------------------
 <h2>Initialize your local repository</h2>
   ```

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "waka-flocka-frame",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "a fast http framework",
   "main": "index.js",
   "directories": {

--- a/test/router-test.js
+++ b/test/router-test.js
@@ -1,5 +1,4 @@
 var chai = require('chai');
-var fs = require('fs');
 var expect = chai.expect;
 var Router = require(__dirname + '/../lib/router');
 
@@ -27,8 +26,8 @@ describe('testing routes', () => {
       done();
     });
     Router.route(
-      {'method': 'GET', 'url': '/test'},
-      {'writeHead': (status) => {
+      { 'method': 'GET', 'url': '/test' },
+      { 'writeHead': (status) => {
         expect(status).to.eql(200);
         this.counter++;
       },
@@ -49,8 +48,8 @@ describe('testing routes', () => {
       done();
     });
     Router.route(
-      {'method': 'POST', 'url': '/test'},
-      {'writeHead': (status) => {
+      { 'method': 'POST', 'url': '/test' },
+      { 'writeHead': (status) => {
         expect(status).to.eql(200);
         this.counter++;
       },


### PR DESCRIPTION
Added a line to the readme stating the need to have Node js installed on the users computer. This should cover the issue about requiring 'fs' in the app. 
Also, it needs to be pointed out that the linter errors are caused by us using block notation rather than dot notation on the router.js file. This was intentional and the app will break if we change it to dot notation. 
